### PR TITLE
remove redundant renderRequest motion value event

### DIFF
--- a/packages/client-core/src/components/Glass/MultiVideo.tsx
+++ b/packages/client-core/src/components/Glass/MultiVideo.tsx
@@ -296,7 +296,6 @@ export const VideoCarousel = ({ handleSidebarOpen, videoElements, videoMediaStre
     [collapsed]
   )
   useMotionValueEvent(scrollYProgress, 'change', positionVideosWithCollapsed)
-  useMotionValueEvent(scrollYProgress, 'renderRequest', positionVideosWithCollapsed)
 
   useLayoutEffect(() => {
     if (!container.current || !videosRef.current || !numVideos) {


### PR DESCRIPTION
## Summary

This PR was pushed to npm, and because the package uses minor version carrot pinning in it's monorepo, it bricked out CI/CD
https://github.com/motiondivision/motion/pull/3317

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
