### PR TITLE
Action API Cleanup

### DIFF
--- a/packages/client-core/src/systems/WidgetUISystem.tsx
+++ b/packages/client-core/src/systems/WidgetUISystem.tsx
@@ -86,9 +86,9 @@ const toggleWidgetsMenu = (handedness: 'left' | 'right' = getState(WidgetAppStat
 const inputSourceQuery = defineQuery([InputSourceComponent])
 
 /** @todo replace action queue with reactor */
-const showWidgetQueue = defineActionQueue(WidgetAppActions.showWidget.matches)
-const registerWidgetQueue = defineActionQueue(WidgetAppActions.registerWidget.matches)
-const unregisterWidgetQueue = defineActionQueue(WidgetAppActions.unregisterWidget.matches)
+const showWidgetQueue = defineActionQueue(WidgetAppActions.showWidget)
+const registerWidgetQueue = defineActionQueue(WidgetAppActions.registerWidget)
+const unregisterWidgetQueue = defineActionQueue(WidgetAppActions.unregisterWidget)
 
 const execute = () => {
   const { widgetMenuUI } = getState(WidgetUISystemState)

--- a/packages/client-core/src/transports/mediasoup/MediasoupClientFunctions.ts
+++ b/packages/client-core/src/transports/mediasoup/MediasoupClientFunctions.ts
@@ -491,8 +491,8 @@ export const onTransportCreated = async (networkID: NetworkID, transportDefiniti
       //  TODO - this is an anti pattern, how else can we resolve this? inject a system?
       try {
         const transportConnected = await new Promise<any>((resolve, reject) => {
-          const actionQueue = defineActionQueue(MediasoupTransportActions.transportConnected.matches)
-          const errorQueue = defineActionQueue(MediasoupTransportActions.requestTransportConnectError.matches)
+          const actionQueue = defineActionQueue(MediasoupTransportActions.transportConnected)
+          const errorQueue = defineActionQueue(MediasoupTransportActions.requestTransportConnectError)
 
           const cleanup = () => {
             destroySystem(systemUUID)
@@ -580,8 +580,8 @@ export const onTransportCreated = async (networkID: NetworkID, transportDefiniti
         //  TODO - this is an anti pattern, how else can we resolve this? inject a system?
         try {
           const producerPromise = await new Promise<any>((resolve, reject) => {
-            const actionQueue = defineActionQueue(MediasoupMediaProducerActions.producerCreated.matches)
-            const errorQueue = defineActionQueue(MediasoupMediaProducerActions.requestProducerError.matches)
+            const actionQueue = defineActionQueue(MediasoupMediaProducerActions.producerCreated)
+            const errorQueue = defineActionQueue(MediasoupMediaProducerActions.requestProducerError)
 
             const cleanup = () => {
               destroySystem(systemUUID)
@@ -646,8 +646,8 @@ export const onTransportCreated = async (networkID: NetworkID, transportDefiniti
         //  TODO - this is an anti pattern, how else can we resolve this? inject a system?
         try {
           const producerPromise = await new Promise<any>((resolve, reject) => {
-            const actionQueue = defineActionQueue(MediasoupDataProducerActions.producerCreated.matches)
-            const errorQueue = defineActionQueue(MediasoupDataProducerActions.requestProducerError.matches)
+            const actionQueue = defineActionQueue(MediasoupDataProducerActions.producerCreated)
+            const errorQueue = defineActionQueue(MediasoupDataProducerActions.requestProducerError)
 
             const cleanup = () => {
               destroySystem(systemUUID)

--- a/packages/client/src/pages/capture/capture.tsx
+++ b/packages/client/src/pages/capture/capture.tsx
@@ -23,7 +23,7 @@ import Debug from '@ir-engine/client-core/src/components/Debug'
 import { AvatarControllerComponent } from '@ir-engine/engine/src/avatar/components/AvatarControllerComponent'
 import { RigidBodyComponent } from '@ir-engine/spatial/src/physics/components/RigidBodyComponent'
 
-const ecsRecordingErrorActionQueue = defineActionQueue(ECSRecordingActions.error.matches)
+const ecsRecordingErrorActionQueue = defineActionQueue(ECSRecordingActions.error)
 
 const NotifyRecordingErrorSystem = defineSystem({
   uuid: 'notifyRecordingErrorSystem',

--- a/packages/common/src/recording/ECSRecordingSystem.ts
+++ b/packages/common/src/recording/ECSRecordingSystem.ts
@@ -787,10 +787,10 @@ const playbackStopped = (userId: UserID, recordingID: RecordingID, network?: Net
 }
 
 /** @todo replace action queue with event sourcing */
-const startRecordingActionQueue = defineActionQueue(ECSRecordingActions.startRecording.matches)
-const stopRecordingActionQueue = defineActionQueue(ECSRecordingActions.stopRecording.matches)
-const startPlaybackActionQueue = defineActionQueue(ECSRecordingActions.startPlayback.matches)
-const stopPlaybackActionQueue = defineActionQueue(ECSRecordingActions.stopPlayback.matches)
+const startRecordingActionQueue = defineActionQueue(ECSRecordingActions.startRecording)
+const stopRecordingActionQueue = defineActionQueue(ECSRecordingActions.stopRecording)
+const startPlaybackActionQueue = defineActionQueue(ECSRecordingActions.startPlayback)
+const stopPlaybackActionQueue = defineActionQueue(ECSRecordingActions.stopPlayback)
 
 const execute = () => {
   const recordingState = getState(RecordingState)

--- a/packages/engine/src/avatar/animation/AvatarAnimationGraph.ts
+++ b/packages/engine/src/avatar/animation/AvatarAnimationGraph.ts
@@ -4,17 +4,13 @@ import { AnimationClip, AnimationMixer, LoopOnce, LoopRepeat, Vector3 } from 'th
 import { getComponent } from '@ir-engine/ecs/src/ComponentFunctions'
 import { ECSState } from '@ir-engine/ecs/src/ECSState'
 import { Entity } from '@ir-engine/ecs/src/Entity'
-import { defineActionQueue, getState } from '@ir-engine/hyperflux'
+import { getState } from '@ir-engine/hyperflux'
 import { lerp } from '@ir-engine/spatial/src/common/functions/MathLerpFunctions'
 
 import { AnimationState } from '../AnimationManager'
 import { AnimationComponent } from '../components/AnimationComponent'
 import { AvatarAnimationComponent, AvatarRigComponent } from '../components/AvatarAnimationComponent'
-import { AvatarNetworkAction } from '../state/AvatarNetworkActions'
 import { preloadedAnimations } from './Util'
-
-/** @todo replace this with event sourcing */
-const animationQueue = defineActionQueue(AvatarNetworkAction.setAnimationState.matches)
 
 export const getAnimationAction = (name: string, mixer: AnimationMixer, animations?: AnimationClip[]) => {
   const manager = getState(AnimationState)

--- a/packages/engine/src/avatar/state/AvatarNetworkState.tsx
+++ b/packages/engine/src/avatar/state/AvatarNetworkState.tsx
@@ -31,8 +31,7 @@ export const AvatarState = defineState({
 
   receptors: {
     onSpawn: AvatarNetworkAction.spawn.receive((action) => {
-      const avatarUUID = UUIDComponent.join({ entitySourceID: action.entitySourceID!, entityID: action.entityID })
-
+      const avatarUUID = UUIDComponent.join({ entitySourceID: action.entitySourceID, entityID: action.entityID })
       getMutableState(AvatarState)[avatarUUID].merge({
         avatarURL: action.avatarURL,
         name: action.name

--- a/packages/hyperflux/src/functions/ActionFunctions.ts
+++ b/packages/hyperflux/src/functions/ActionFunctions.ts
@@ -251,10 +251,8 @@ const createEventSourceQueues = (action: Action) => {
   for (const definition of StateDefinitions.values()) {
     if (!definition.receptors || HyperFlux.store.receptors[definition.name]) continue
 
-    const matchedActions = Object.values(definition.receptors)
-      .filter((r: ActionReceptor<any, any, any>) => r.action.test(action))
-      .map((r: ActionReceptor<any, any, any>) => r.action)
-    if (!matchedActions.length) continue
+    const matchedActions = Object.values(definition.receptors).map((r: ActionReceptor<any, any, any>) => r.action)
+    if (!matchedActions.some((m) => m.test(action))) continue
 
     const receptorActionQueue = defineActionQueue(matchedActions)
     definition.receptorActionQueue = receptorActionQueue

--- a/packages/hyperflux/src/functions/ActionFunctions.ts
+++ b/packages/hyperflux/src/functions/ActionFunctions.ts
@@ -390,7 +390,7 @@ export function defineActionQueue<A extends ActionCreator<any, any, any>>(action
     return result
   }
 
-  actionQueueGetter.test = (a: A) => actionDefinitions.some((s) => s(a))
+  actionQueueGetter.test = (a: A) => actionDefinitions.some((s) => s.test(a))
 
   actionQueueGetter.instance = null as any
   Object.defineProperty(actionQueueGetter, 'instance', {

--- a/packages/hyperflux/src/functions/ActionFunctions.ts
+++ b/packages/hyperflux/src/functions/ActionFunctions.ts
@@ -107,7 +107,7 @@ export type ActionReceptor<
   Schema extends TObjectSchema<Properties>,
   TType extends string
 > = ((action: ResolvedAction<TType, Properties, Schema>) => void) & {
-  matchesAction: ActionMatcher<ResolvedAction<TType, Properties, Schema>>
+  action: ActionCreator<TType, Properties, Schema>
   validate: (
     filter: (action: ResolvedAction<TType, Properties, Schema>) => boolean
   ) => ActionReceptor<Properties, Schema, TType>
@@ -180,7 +180,7 @@ export function defineAction<
   }
   creator.receive = (receptor) => {
     const hookable = createHookableFunction(receptor) as any
-    hookable.matchesAction = (a: Action) => creator.test(a)
+    hookable.action = creator
     hookable.validate = (fn) => {
       hookable.validator = fn
       return hookable
@@ -251,9 +251,9 @@ const createEventSourceQueues = (action: Action) => {
   for (const definition of StateDefinitions.values()) {
     if (!definition.receptors || HyperFlux.store.receptors[definition.name]) continue
 
-    const matchedActions = Object.values(definition.receptors).filter((r: ActionReceptor<any, any, any>) =>
-      r.matchesAction(action)
-    ) as ActionCreator<any, any, any>[]
+    const matchedActions = Object.values(definition.receptors)
+      .filter((r: ActionReceptor<any, any, any>) => r.action.test(action))
+      .map((r: ActionReceptor<any, any, any>) => r.action)
     if (!matchedActions.length) continue
 
     const receptorActionQueue = defineActionQueue(matchedActions)
@@ -272,7 +272,7 @@ const createEventSourceQueues = (action: Action) => {
         for (const defReceptor of Object.values(definition.receptors!)) {
           try {
             const receptor = defReceptor as ActionReceptor<any, any, any>
-            if (receptor.matchesAction(act)) {
+            if (receptor.action.test(act)) {
               if (receptor.validator && !receptor.validator(act)) continue
               receptor(act)
               hasNewActions = true
@@ -363,9 +363,8 @@ export const clearOutgoingActions = (topic: Topic) => {
 
 export type ActionMatcher<A extends Action> = (a: A) => boolean
 
-export function defineActionQueue<A extends ActionCreator<any, any, any>>(matchers: A | A[]) {
-  const shapes = Array.isArray(matchers) ? matchers : [matchers]
-  const shapeHash = shapes.map((_, i) => `m${i}`).join('|')
+export function defineActionQueue<A extends ActionCreator<any, any, any>>(actionDefinition: A | A[]) {
+  const actionDefinitions = Array.isArray(actionDefinition) ? actionDefinition : [actionDefinition]
 
   const getOrCreateInstance = () => {
     const queueMap = HyperFlux.store.actions.queues
@@ -391,8 +390,7 @@ export function defineActionQueue<A extends ActionCreator<any, any, any>>(matche
     return result
   }
 
-  actionQueueGetter.test = (a: A) => shapes.some((s) => s(a))
-  actionQueueGetter.shapeHash = shapeHash
+  actionQueueGetter.test = (a: A) => actionDefinitions.some((s) => s(a))
 
   actionQueueGetter.instance = null as any
   Object.defineProperty(actionQueueGetter, 'instance', {
@@ -424,7 +422,6 @@ export function defineActionQueue<A extends ActionCreator<any, any, any>>(matche
 export type ActionQueueHandle<A extends ActionCreator<any, any, any>> = {
   (): A['_TYPE'][]
   test: (a: A['_TYPE']) => boolean
-  shapeHash: string
   needsResync: boolean
   instance: ActionQueueInstance<A>
   resync: () => void

--- a/packages/hyperflux/src/functions/ActionFunctions.ts
+++ b/packages/hyperflux/src/functions/ActionFunctions.ts
@@ -77,21 +77,6 @@ export type ActionOptions = {
   $ERROR?: { message: string; stack: string[] }
 }
 
-/** Utility: deep equality (used in caching logic) */
-export function deepEqual(x: any, y: any): boolean {
-  if (x === y) return true
-  if (typeof x == 'object' && x != null && typeof y == 'object' && y != null) {
-    if (Object.keys(x).length != Object.keys(y).length) return false
-    for (const prop in x) {
-      if (typeof y[prop] !== 'undefined') {
-        if (!deepEqual(x[prop], y[prop])) return false
-      } else return false
-    }
-    return true
-  }
-  return false
-}
-
 export type ResolvedAction<
   TType extends string,
   Properties extends TProperties,
@@ -112,7 +97,6 @@ export interface ActionCreator<
     extensionDefinition: ExtendSchema
   ) => MergeObjectSchemas<Schema, ExtendSchema>
   test: (a: Action) => a is ResolvedAction<TType, Properties, Schema>
-  matches: ActionMatcher<ResolvedAction<TType, Properties, Schema>>
   receive: (
     receptor: (action: ResolvedAction<TType, Properties, Schema>) => void
   ) => ActionReceptor<Properties, Schema, TType>
@@ -194,19 +178,15 @@ export function defineAction<
     for (const key of Object.keys(definition.properties || {})) subset[key] = a[key]
     return validate(subset)
   }
-  creator.matches = { test: (a: Action) => creator.test(a) }
   creator.receive = (receptor) => {
     const hookable = createHookableFunction(receptor) as any
-    hookable.matchesAction = { test: (a: Action) => creator.test(a) }
+    hookable.matchesAction = (a: Action) => creator.test(a)
     hookable.validate = (fn) => {
       hookable.validator = fn
       return hookable
     }
     return hookable as ActionReceptor<Properties, Schema, TType>
   }
-
-  // this is a hack to get the type of the action at compile time
-  creator['_TYPE'] = null as any
 
   ActionDefinitions[primaryType] = creator
   return creator
@@ -271,10 +251,10 @@ const createEventSourceQueues = (action: Action) => {
   for (const definition of StateDefinitions.values()) {
     if (!definition.receptors || HyperFlux.store.receptors[definition.name]) continue
 
-    const matchedActions = Object.values(definition.receptors).map(
-      (r: ActionReceptor<any, any, any>) => r.matchesAction
-    )
-    if (!matchedActions.some((m) => m.test(action))) continue
+    const matchedActions = Object.values(definition.receptors).filter((r: ActionReceptor<any, any, any>) =>
+      r.matchesAction(action)
+    ) as ActionCreator<any, any, any>[]
+    if (!matchedActions.length) continue
 
     const receptorActionQueue = defineActionQueue(matchedActions)
     definition.receptorActionQueue = receptorActionQueue
@@ -292,7 +272,7 @@ const createEventSourceQueues = (action: Action) => {
         for (const defReceptor of Object.values(definition.receptors!)) {
           try {
             const receptor = defReceptor as ActionReceptor<any, any, any>
-            if (receptor.matchesAction.test(act)) {
+            if (receptor.matchesAction(act)) {
               if (receptor.validator && !receptor.validator(act)) continue
               receptor(act)
               hasNewActions = true
@@ -381,9 +361,9 @@ export const clearOutgoingActions = (topic: Topic) => {
   queue.length = 0
 }
 
-export type ActionMatcher<A extends Action> = { test: (a: A) => boolean }
+export type ActionMatcher<A extends Action> = (a: A) => boolean
 
-export function defineActionQueue<A extends Action>(matchers: ActionMatcher<A> | ActionMatcher<A>[]) {
+export function defineActionQueue<A extends ActionCreator<any, any, any>>(matchers: A | A[]) {
   const shapes = Array.isArray(matchers) ? matchers : [matchers]
   const shapeHash = shapes.map((_, i) => `m${i}`).join('|')
 
@@ -411,7 +391,7 @@ export function defineActionQueue<A extends Action>(matchers: ActionMatcher<A> |
     return result
   }
 
-  actionQueueGetter.test = (a: A) => shapes.some((s) => s.test(a))
+  actionQueueGetter.test = (a: A) => shapes.some((s) => s(a))
   actionQueueGetter.shapeHash = shapeHash
 
   actionQueueGetter.instance = null as any
@@ -432,8 +412,8 @@ export function defineActionQueue<A extends Action>(matchers: ActionMatcher<A> |
   actionQueueGetter.resync = () => {
     const queue = getOrCreateInstance()
     queue.actions = HyperFlux.store.actions.history
-      .filter((a: Action) => actionQueueGetter.test(a as A))
-      .sort((a: Action, b: Action) => (a.$time || 0) - (b.$time || 0)) as A[]
+      .filter((a: Action) => actionQueueGetter.test(a))
+      .sort((a: A['_TYPE'], b: A['_TYPE']) => (a.$time || 0) - (b.$time || 0)) as A['_TYPE'][]
     queue.nextIndex = 0
     queue.needsResync = false
   }
@@ -441,22 +421,22 @@ export function defineActionQueue<A extends Action>(matchers: ActionMatcher<A> |
   return actionQueueGetter
 }
 
-export type ActionQueueHandle<A extends Action> = {
-  (): A[]
-  test: (a: A) => boolean
+export type ActionQueueHandle<A extends ActionCreator<any, any, any>> = {
+  (): A['_TYPE'][]
+  test: (a: A['_TYPE']) => boolean
   shapeHash: string
   needsResync: boolean
   instance: ActionQueueInstance<A>
   resync: () => void
 }
 
-export type ActionQueueInstance<A extends Action> = {
-  actions: A[]
+export type ActionQueueInstance<A extends ActionCreator<any, any, any>> = {
+  actions: A['_TYPE'][]
   nextIndex: number
   needsResync: boolean
   reactorRoot: ReactorRoot | undefined
 }
 
-export const removeActionQueue = <A extends Action>(queueHandle: ActionQueueHandle<A>) => {
+export const removeActionQueue = <A extends ActionCreator<any, any, any>>(queueHandle: ActionQueueHandle<A>) => {
   HyperFlux.store.actions.queues.delete(queueHandle)
 }

--- a/packages/hyperflux/tests/hyperflux.test.ts
+++ b/packages/hyperflux/tests/hyperflux.test.ts
@@ -441,7 +441,7 @@ describe('Hyperflux Unit Tests', () => {
     const store = createHyperStore({
       getDispatchTime: () => Date.now()
     })
-    const queue = defineActionQueue([greet.matches, goodbye.matches])
+    const queue = defineActionQueue([greet, goodbye])
     assert.equal(queue().length, 0)
     dispatchAction(greet({}))
     dispatchAction(goodbye({}))
@@ -484,7 +484,7 @@ describe('Hyperflux Unit Tests', () => {
       getDispatchTime: () => Date.now()
     })
 
-    const queue = defineActionQueue([greet.matches, goodbye.matches])
+    const queue = defineActionQueue([greet, goodbye])
     dispatchAction(goodbye({ $time: 200 }))
     dispatchAction(greet({ $time: 100 }))
 
@@ -533,8 +533,8 @@ describe('Hyperflux Unit Tests', () => {
       getDispatchTime: () => Date.now()
     })
 
-    const queue1 = defineActionQueue([greet.matches, goodbye.matches])
-    const queue2 = defineActionQueue([greet.matches, goodbye.matches])
+    const queue1 = defineActionQueue([greet, goodbye])
+    const queue2 = defineActionQueue([greet, goodbye])
     dispatchAction(goodbye({ $time: 200 }))
     dispatchAction(greet({ $time: 100 }))
     applyIncomingActions()
@@ -581,7 +581,7 @@ describe('Hyperflux Unit Tests', () => {
       getDispatchTime: () => Date.now()
     })
 
-    const queue = defineActionQueue([greet.matches, goodbye.matches])
+    const queue = defineActionQueue([greet, goodbye])
     dispatchAction(goodbye({ $time: 200 }))
     dispatchAction(greet({ $time: 100 }))
     applyIncomingActions()

--- a/packages/instanceserver/src/MediasoupServerSystem.tsx
+++ b/packages/instanceserver/src/MediasoupServerSystem.tsx
@@ -39,17 +39,17 @@ import {
 } from './WebRTCFunctions'
 
 /** We do not need event sourcing here, as these actions only exist for the lifetime of the peer's connection */
-const requestConsumerActionQueue = defineActionQueue(MediasoupMediaConsumerActions.requestConsumer.matches)
-const consumerLayersActionQueue = defineActionQueue(MediasoupMediaConsumerActions.consumerLayers.matches)
-const requestProducerActionQueue = defineActionQueue(MediasoupMediaProducerActions.requestProducer.matches)
-const closeProducerActionQueue = defineActionQueue(MediasoupMediaProducerActions.producerClosed.matches)
-const closeConsumerActionQueue = defineActionQueue(MediasoupMediaConsumerActions.consumerClosed.matches)
+const requestConsumerActionQueue = defineActionQueue(MediasoupMediaConsumerActions.requestConsumer)
+const consumerLayersActionQueue = defineActionQueue(MediasoupMediaConsumerActions.consumerLayers)
+const requestProducerActionQueue = defineActionQueue(MediasoupMediaProducerActions.requestProducer)
+const closeProducerActionQueue = defineActionQueue(MediasoupMediaProducerActions.producerClosed)
+const closeConsumerActionQueue = defineActionQueue(MediasoupMediaConsumerActions.consumerClosed)
 
-const dataRequestProducerActionQueue = defineActionQueue(MediasoupDataProducerActions.requestProducer.matches)
-const dataRequestConsumerActionQueue = defineActionQueue(MediasoupDataConsumerActions.requestConsumer.matches)
+const dataRequestProducerActionQueue = defineActionQueue(MediasoupDataProducerActions.requestProducer)
+const dataRequestConsumerActionQueue = defineActionQueue(MediasoupDataConsumerActions.requestConsumer)
 
-const requestTransportActionQueue = defineActionQueue(MediasoupTransportActions.requestTransport.matches)
-const requestTransportConnectActionQueue = defineActionQueue(MediasoupTransportActions.requestTransportConnect.matches)
+const requestTransportActionQueue = defineActionQueue(MediasoupTransportActions.requestTransport)
+const requestTransportConnectActionQueue = defineActionQueue(MediasoupTransportActions.requestTransportConnect)
 
 const execute = () => {
   for (const action of requestConsumerActionQueue()) {

--- a/packages/spatial/src/camera/systems/CameraFadeBlackEffectSystem.tsx
+++ b/packages/spatial/src/camera/systems/CameraFadeBlackEffectSystem.tsx
@@ -21,7 +21,7 @@ import { TransformComponent } from '../../transform/components/TransformComponen
 import { CameraActions } from '../CameraState'
 import { CameraSystem } from './CameraSystem'
 
-const fadeToBlackQueue = defineActionQueue(CameraActions.fadeToBlack.matches)
+const fadeToBlackQueue = defineActionQueue(CameraActions.fadeToBlack)
 
 const CameraFadeBlackEffectSystemState = defineState({
   name: 'CameraFadeBlackEffectSystemState',

--- a/packages/spatial/src/xr/VPSSystem.ts
+++ b/packages/spatial/src/xr/VPSSystem.ts
@@ -8,9 +8,9 @@ import { PersistentAnchorActions, PersistentAnchorComponent } from './XRAnchorCo
 import { XRPersistentAnchorSystem } from './XRPersistentAnchorSystem'
 
 const vpsAnchorQuery = defineQuery([PersistentAnchorComponent])
-const vpsAnchorFoundQueue = defineActionQueue(PersistentAnchorActions.anchorFound.matches)
-const vpsAnchorUpdatedQueue = defineActionQueue(PersistentAnchorActions.anchorUpdated.matches)
-const vpsAnchorLostQueue = defineActionQueue(PersistentAnchorActions.anchorLost.matches)
+const vpsAnchorFoundQueue = defineActionQueue(PersistentAnchorActions.anchorFound)
+const vpsAnchorUpdatedQueue = defineActionQueue(PersistentAnchorActions.anchorUpdated)
+const vpsAnchorLostQueue = defineActionQueue(PersistentAnchorActions.anchorLost)
 
 const execute = () => {
   const anchors = vpsAnchorQuery()


### PR DESCRIPTION
## Summary

This pull request refactors the usage of `defineActionQueue` across the codebase to simplify its interface and improve type safety. Instead of passing `.matches` or matcher objects, the code now passes action creator objects directly to `defineActionQueue`. Additionally, related types and internal logic in `ActionFunctions.ts` have been updated to support this change, removing unnecessary complexity and improving clarity. This change affects many systems that use action queues, including networking, recording, animation, and spatial systems.

**Core API and Type Refactor:**

* Updated `defineActionQueue` in `ActionFunctions.ts` to accept action creator objects directly instead of matcher objects, and refactored related types and internal logic to improve type safety and clarity. This includes removing the `.matches` property from action creators, updating `ActionQueueHandle` and `ActionQueueInstance` types, and adjusting how receptors and queues interact with actions. [[1]](diffhunk://#diff-08fe18ee77b3c12b175006329a3755f45c70e1c103ff1850e29c7f0cc12cb4aeL115) [[2]](diffhunk://#diff-08fe18ee77b3c12b175006329a3755f45c70e1c103ff1850e29c7f0cc12cb4aeL126-R110) [[3]](diffhunk://#diff-08fe18ee77b3c12b175006329a3755f45c70e1c103ff1850e29c7f0cc12cb4aeL197-L210) [[4]](diffhunk://#diff-08fe18ee77b3c12b175006329a3755f45c70e1c103ff1850e29c7f0cc12cb4aeL274-R254) [[5]](diffhunk://#diff-08fe18ee77b3c12b175006329a3755f45c70e1c103ff1850e29c7f0cc12cb4aeL295-R273) [[6]](diffhunk://#diff-08fe18ee77b3c12b175006329a3755f45c70e1c103ff1850e29c7f0cc12cb4aeL384-R365) [[7]](diffhunk://#diff-08fe18ee77b3c12b175006329a3755f45c70e1c103ff1850e29c7f0cc12cb4aeL414-R391) [[8]](diffhunk://#diff-08fe18ee77b3c12b175006329a3755f45c70e1c103ff1850e29c7f0cc12cb4aeL435-R435)

**Codebase-wide Action Queue Usage Update:**

* Replaced all usages of `.matches` or matcher objects with direct action creator objects in calls to `defineActionQueue` throughout the codebase, including networking (`MediasoupClientFunctions.ts`, `MediasoupServerSystem.tsx`), recording (`ECSRecordingSystem.ts`, `capture.tsx`), animation (`AvatarAnimationGraph.ts`), widget UI (`WidgetUISystem.tsx`), camera systems (`CameraFadeBlackEffectSystem.tsx`), and spatial XR systems (`VPSSystem.ts`). [[1]](diffhunk://#diff-e12ba91bc749e0c07a95059ad685782fcde81fff369acb8416d1da04481bdfc3L494-R495) [[2]](diffhunk://#diff-e12ba91bc749e0c07a95059ad685782fcde81fff369acb8416d1da04481bdfc3L583-R584) [[3]](diffhunk://#diff-e12ba91bc749e0c07a95059ad685782fcde81fff369acb8416d1da04481bdfc3L649-R650) [[4]](diffhunk://#diff-229fb39659905ba4b86d0774bd463e8385fb9672faf2ea8c612915a1eaeac7b9L26-R26) [[5]](diffhunk://#diff-c43e94f81924f20654f8217bff04bf28e55c57fcfcb1003b0a94d1320cfb4fc1L790-R793) [[6]](diffhunk://#diff-de7cee7a1f4d1d8da9d60f2ab9fecaaf29a593efa35d621a369ddf0c03304e6bL42-R52) [[7]](diffhunk://#diff-253e88fe8933ca9f10c158f1f23299414f1039f72446e775e43c80e3c1e9da14L89-R91) [[8]](diffhunk://#diff-88dcafbfbe0ed41e4dcec5d3cd0b48c3b0bf750dc3b870d2b26cd76416757c79L24-R24) [[9]](diffhunk://#diff-d84146b44b8984acdeda26d8cecac55c51cd8779fe483e9c7712c022842da7eeL11-R13)

**Test Suite Update:**

* Updated unit tests in `hyperflux.test.ts` to use action creators directly in `defineActionQueue` calls, ensuring the new API is properly tested and validated. [[1]](diffhunk://#diff-7770144bd5d7b1ac9d01ee487e4f2f1d3f9274282a06a2304bfb4c1b42ea790fL444-R444) [[2]](diffhunk://#diff-7770144bd5d7b1ac9d01ee487e4f2f1d3f9274282a06a2304bfb4c1b42ea790fL487-R487) [[3]](diffhunk://#diff-7770144bd5d7b1ac9d01ee487e4f2f1d3f9274282a06a2304bfb4c1b42ea790fL536-R537) [[4]](diffhunk://#diff-7770144bd5d7b1ac9d01ee487e4f2f1d3f9274282a06a2304bfb4c1b42ea790fL584-R584)

**Minor Cleanup:**

* Removed unused or obsolete code, such as the `deepEqual` utility function from `ActionFunctions.ts`, which is no longer needed after the refactor.

**Small Bug Fix:**

* Fixed a minor bug in `AvatarNetworkState.tsx` by removing unnecessary non-null assertion on `action.entitySourceID`.

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
