### PR TITLE
various avatar input fixes

### DIFF
--- a/packages/ecs/src/EntityTree.tsx
+++ b/packages/ecs/src/EntityTree.tsx
@@ -1,6 +1,6 @@
 import { NO_PROXY, Schema, startReactor, useForceUpdate, useHookstate, useImmediateEffect } from '@ir-engine/hyperflux'
 import * as bitECS from 'bitecs'
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import {
   Component,
   ComponentType,
@@ -428,7 +428,10 @@ export function useQueryBySource(
   layer = Layers.Simulation
 ): Entity[] {
   const query = useQuery([...queryTerms], layer)
-  return query.filter((e) => hasComponent(e, UUIDComponent) && UUIDComponent.getSourceEntity(e) === sourceEntity)
+  const filtered = query.filter(
+    (e) => hasComponent(e, UUIDComponent) && UUIDComponent.getSourceEntity(e) === sourceEntity
+  )
+  return useMemo(() => [...filtered], [JSON.stringify(filtered)])
 }
 
 /**

--- a/packages/engine/src/avatar/animation/TwoBoneIKSolver.ts
+++ b/packages/engine/src/avatar/animation/TwoBoneIKSolver.ts
@@ -201,11 +201,15 @@ const targetPos = new Vector3(),
   rootWorldRotation = new Quaternion()
 
 const nodeQuaternion = new Quaternion()
-export const blendIKChain = (bones: Entity[], weight) => {
+export const blendIKChain = (bones: Entity[], weight: number) => {
   for (const bone of bones) {
     const node = getComponent(bone, BoneComponent)
     const ikMatrix = getComponent(bone, IKMatrixComponent).local
     nodeQuaternion.setFromRotationMatrix(ikMatrix)
+    if (weight >= 1) {
+      node.quaternion.copy(nodeQuaternion)
+      continue
+    }
     node.quaternion.fastSlerp(nodeQuaternion, weight)
   }
 }

--- a/packages/engine/src/avatar/components/AvatarIKComponents.ts
+++ b/packages/engine/src/avatar/components/AvatarIKComponents.ts
@@ -32,7 +32,7 @@ export const AvatarIKTargetComponent = defineComponent({
     const entity = useEntityContext()
     const debugEnabled = useHookstate(getMutableState(RendererState).avatarDebug)
 
-    useHelperEntity(entity, () => new AxesHelper(0.125), debugEnabled.value, ObjectLayerMasks.AvatarHelper)
+    useHelperEntity(entity, () => new AxesHelper(0.5), debugEnabled.value, ObjectLayerMasks.AvatarHelper)
 
     return null
   },
@@ -70,20 +70,20 @@ export const getHandTarget = (entity: Entity, hand: XRHandedness): HandTargetRet
   switch (hand) {
     case 'left': {
       return {
-        position: TransformComponent.getWorldPosition(rig.leftHand, vec3),
-        rotation: TransformComponent.getWorldRotation(rig.leftHand, quat)
+        position: TransformComponent.getScenePosition(rig.leftHand, vec3),
+        rotation: TransformComponent.getSceneRotation(rig.leftHand, quat)
       }
     }
     case 'right':
       return {
-        position: TransformComponent.getWorldPosition(rig.rightHand, vec3),
-        rotation: TransformComponent.getWorldRotation(rig.rightHand, quat)
+        position: TransformComponent.getScenePosition(rig.rightHand, vec3),
+        rotation: TransformComponent.getSceneRotation(rig.rightHand, quat)
       }
     default:
     case 'none':
       return {
-        position: TransformComponent.getWorldPosition(rig.head, vec3),
-        rotation: TransformComponent.getWorldRotation(rig.head, quat)
+        position: TransformComponent.getScenePosition(rig.head, vec3),
+        rotation: TransformComponent.getSceneRotation(rig.head, quat)
       }
   }
 }

--- a/packages/engine/src/avatar/functions/moveAvatar.ts
+++ b/packages/engine/src/avatar/functions/moveAvatar.ts
@@ -1,6 +1,6 @@
 import { Euler, Matrix4, Quaternion, Vector3 } from 'three'
 
-import { NetworkObjectAuthorityTag, UUIDComponent } from '@ir-engine/ecs'
+import { getAncestorWithComponents, NetworkObjectAuthorityTag, UUIDComponent } from '@ir-engine/ecs'
 import { ComponentType, getComponent, getOptionalComponent, hasComponent } from '@ir-engine/ecs/src/ComponentFunctions'
 import { ECSState } from '@ir-engine/ecs/src/ECSState'
 import { Entity } from '@ir-engine/ecs/src/Entity'
@@ -21,6 +21,7 @@ import { XRState } from '@ir-engine/spatial/src/xr/XRState'
 
 import { ReferenceSpaceState } from '@ir-engine/spatial'
 import { SpawnPoseState } from '@ir-engine/spatial/src/transform/SpawnPoseState'
+import { GrabbedComponent } from '../../grabbable/GrabbableComponent'
 import { preloadedAnimations } from '../animation/Util'
 import { AvatarComponent } from '../components/AvatarComponent'
 import { AvatarColliderComponent, AvatarControllerComponent } from '../components/AvatarControllerComponent'
@@ -110,7 +111,13 @@ export function moveAvatar(entity: Entity, additionalMovement?: Vector3) {
     bodyCollider.collisionMask & ~CollisionGroups.Trigger
   )
 
-  Physics.computeColliderMovement(world, entity, colliderEntity, desiredMovement, avatarCollisionGroups)
+  Physics.computeColliderMovement(world, entity, colliderEntity, desiredMovement, avatarCollisionGroups, (collider) => {
+    const grabbedParent = getAncestorWithComponents(collider.entity, [RigidBodyComponent, GrabbedComponent])
+    if (grabbedParent) {
+      return getComponent(grabbedParent, GrabbedComponent).grabberEntity !== entity
+    }
+    return true
+  })
   Physics.getComputedMovement(world, entity, computedMovement)
 
   if (desiredMovement.y === 0) computedMovement.y = 0

--- a/packages/engine/src/avatar/systems/AvatarIKSystem.tsx
+++ b/packages/engine/src/avatar/systems/AvatarIKSystem.tsx
@@ -110,6 +110,15 @@ const execute = () => {
     const head = AvatarIKTargetComponent.getTargetEntity(ownerID, ikTargets.head)
     const headTargetBlendWeight = AvatarIKTargetComponent.blendWeight[head]
 
+    const hasATarget = !!(
+      leftFootTargetBlendWeight ||
+      rightFootTargetBlendWeight ||
+      leftHandTargetBlendWeight ||
+      rightHandTargetBlendWeight ||
+      headTargetBlendWeight
+    )
+    if (!hasATarget) continue
+
     const rotation = TransformComponent.getSceneRotation(entity, _worldRot)
 
     if (headTargetBlendWeight) {
@@ -132,17 +141,18 @@ const execute = () => {
         getComponent(rig.spine, BoneComponent).getWorldQuaternion(_quat).invert(),
         _quat2
       )
-
-      iterateEntityNode(
-        rig.hips,
-        (e) => {
-          getComponent(e, BoneComponent).matrixWorld.multiply(
-            _mat4.makeRotationFromQuaternion(rigComponent.parentWorldRotationInverses.hips)
-          )
-        },
-        (e) => hasComponent(e, BoneComponent)
-      )
     }
+
+    // update world matrices with new hip position
+    iterateEntityNode(
+      rig.hips,
+      (e) => {
+        getComponent(e, BoneComponent).matrixWorld.multiply(
+          _mat4.makeRotationFromQuaternion(rigComponent.parentWorldRotationInverses.hips)
+        )
+      },
+      (e) => hasComponent(e, BoneComponent)
+    )
 
     if (rightHandTargetBlendWeight && rightHandTransform) {
       getArmIKHint(

--- a/packages/engine/src/avatar/systems/AvatarInputSystem.ts
+++ b/packages/engine/src/avatar/systems/AvatarInputSystem.ts
@@ -13,10 +13,10 @@ import { defineQuery } from '@ir-engine/ecs/src/QueryFunctions'
 import { defineSystem } from '@ir-engine/ecs/src/SystemFunctions'
 import { getState } from '@ir-engine/hyperflux'
 import { Vector3_Up, Vector3_Zero } from '@ir-engine/spatial/src/common/constants/MathConstants'
-import { InputComponent } from '@ir-engine/spatial/src/input/components/InputComponent'
+import { InputButtonBindings, InputComponent } from '@ir-engine/spatial/src/input/components/InputComponent'
 import { InputPointerComponent } from '@ir-engine/spatial/src/input/components/InputPointerComponent'
 import { InputSourceComponent } from '@ir-engine/spatial/src/input/components/InputSourceComponent'
-import { StandardGamepadButton } from '@ir-engine/spatial/src/input/state/ButtonState'
+import { KeyboardButton, StandardGamepadButton } from '@ir-engine/spatial/src/input/state/ButtonState'
 import { InputState } from '@ir-engine/spatial/src/input/state/InputState'
 import { ClientInputSystem } from '@ir-engine/spatial/src/input/systems/ClientInputSystem'
 import { RigidBodyFixedTagComponent } from '@ir-engine/spatial/src/physics/components/RigidBodyComponent'
@@ -35,6 +35,17 @@ import { EngineState, Entity } from '@ir-engine/ecs'
 import { ReferenceSpaceState } from '@ir-engine/spatial'
 import { isMobile } from '@ir-engine/spatial/src/common/functions/isMobile'
 import { getThumbstickOrThumbpadAxes } from '@ir-engine/spatial/src/input/functions/getThumbstickOrThumbpadAxes'
+
+export const AvatarButtonBindings = {
+  Left: [KeyboardButton.KeyA, KeyboardButton.ArrowLeft, StandardGamepadButton.StandardGamepadDPadLeft],
+  Right: [KeyboardButton.KeyD, KeyboardButton.ArrowRight, StandardGamepadButton.StandardGamepadDPadRight],
+  Forward: [KeyboardButton.KeyW, KeyboardButton.ArrowUp, StandardGamepadButton.StandardGamepadDPadUp],
+  Backward: [KeyboardButton.KeyS, KeyboardButton.ArrowDown, StandardGamepadButton.StandardGamepadDPadDown],
+  Jump: [KeyboardButton.Space, StandardGamepadButton.StandardGamepadButtonA],
+  Interact: [KeyboardButton.KeyE, StandardGamepadButton.StandardGamepadButtonX],
+  ToggleRun: [KeyboardButton.ShiftLeft],
+  ShiftRight: [KeyboardButton.ShiftRight]
+} satisfies InputButtonBindings
 
 const _quat = new Quaternion()
 
@@ -90,7 +101,7 @@ export const AvatarAxesControlSchemeBehavior = {
 //   groups: interactionGroups
 // } as RaycastArgs
 
-const onShiftLeft = () => {
+const onToggleRun = () => {
   const entity = AvatarComponent.getSelfAvatarEntity()
   if (!entity) return
   setComponent(entity, AvatarControllerComponent, {
@@ -215,33 +226,21 @@ const execute = () => {
 
   if (!isMobile && !inputPointerEntity && !xrState.session) return
 
-  const buttons = InputComponent.getButtons(viewerEntity)
+  const buttons = InputComponent.getButtons(viewerEntity, AvatarButtonBindings)
 
-  if (buttons.ShiftLeft?.down) onShiftLeft()
+  if (buttons.ToggleRun?.down) onToggleRun()
 
   const gamepadJump = buttons[StandardGamepadButton.StandardGamepadButtonA]?.down
 
   //** touch input (only for avatar jump)*/
   const doubleClicked = shouldViewerFollowController ? false : getAvatarDoubleClick(buttons)
   /** keyboard input */
-  const keyDeltaX =
-    (buttons.KeyA?.pressed ? -1 : 0) +
-    (buttons.KeyD?.pressed ? 1 : 0) +
-    (buttons.ArrowLeft?.pressed ? -1 : 0) +
-    (buttons.ArrowRight?.pressed ? 1 : 0) +
-    (buttons[StandardGamepadButton.StandardGamepadDPadLeft]?.pressed ? -1 : 0) +
-    (buttons[StandardGamepadButton.StandardGamepadDPadRight]?.pressed ? 1 : 0)
-  const keyDeltaZ =
-    (buttons.KeyW?.pressed ? -1 : 0) +
-    (buttons.KeyS?.pressed ? 1 : 0) +
-    (buttons.ArrowUp?.pressed ? -1 : 0) +
-    (buttons.ArrowDown?.pressed ? 1 : 0) +
-    (buttons[StandardGamepadButton.StandardGamepadDPadUp]?.pressed ? -1 : 0) +
-    (buttons[StandardGamepadButton.StandardGamepadDPadDown]?.pressed ? -1 : 0)
+  const keyDeltaX = (buttons.Left?.pressed ? -1 : 0) + (buttons.Right?.pressed ? 1 : 0)
+  const keyDeltaZ = (buttons.Forward?.pressed ? -1 : 0) + (buttons.Backward?.pressed ? 1 : 0)
 
   controller.gamepadLocalInput.set(keyDeltaX, 0, keyDeltaZ).normalize()
 
-  controller.gamepadJumpActive = !!buttons.Space?.pressed || gamepadJump || doubleClicked
+  controller.gamepadJumpActive = !!buttons.Jump?.pressed || gamepadJump || doubleClicked
 
   // TODO: refactor AvatarControlSchemes to allow multiple input sources to be passed
   for (const eid of InputSourceComponent.nonCapturedInputSources()) {

--- a/packages/engine/src/grabbable/GrabbableComponent.ts
+++ b/packages/engine/src/grabbable/GrabbableComponent.ts
@@ -5,7 +5,6 @@ import { defineComponent, setComponent, useHasComponent } from '@ir-engine/ecs/s
 import { Entity } from '@ir-engine/ecs/src/Entity'
 import { defineAction, dispatchAction, getState, isClient } from '@ir-engine/hyperflux'
 import { setCallback } from '@ir-engine/spatial/src/common/CallbackComponent'
-import { InputSourceComponent } from '@ir-engine/spatial/src/input/components/InputSourceComponent'
 import { InputState } from '@ir-engine/spatial/src/input/state/InputState'
 
 import { EntitySchema } from '@ir-engine/ecs'
@@ -61,7 +60,7 @@ export const GrabbableComponent = defineComponent({
 
     const grabber = getComponent(grabberEntity, GrabberComponent)
     const grabbedEntity = grabber[handedness]!
-    if (grabbedEntity) return
+    if (grabbedEntity) GrabbableComponent.drop(grabberEntity, grabbedEntity)
     dispatchAction(
       GrabbableNetworkAction.setGrabbedObject({
         entityUUID: UUIDComponent.get(grabbableEntity),
@@ -91,20 +90,13 @@ export const GrabbableComponent = defineComponent({
 })
 
 const grabCallback = (grabbableEntity: Entity) => {
-  const nonCapturedInputSources = InputSourceComponent.nonCapturedInputSources()
   const selfAvatarEntity = AvatarComponent.getSelfAvatarEntity()
-  for (const entity of nonCapturedInputSources) {
-    const inputSource = getComponent(entity, InputSourceComponent)
-    if (hasComponent(grabbableEntity, GrabbedComponent)) {
-      GrabbableComponent.drop(selfAvatarEntity, grabbableEntity)
-    } else {
-      GrabbableComponent.grab(
-        selfAvatarEntity,
-        grabbableEntity,
-        inputSource.source.handedness === 'left' ? 'left' : 'right'
-      )
-    }
-  }
+  GrabbableComponent.grab(
+    selfAvatarEntity,
+    grabbableEntity,
+    'right' /** @todo implement proper XR grabbing by passing interaction source down through callbacks */
+    // inputSource.source.handedness === 'left' ? 'left' : 'right'
+  )
 }
 
 /**

--- a/packages/engine/src/grabbable/GrabbableComponent.ts
+++ b/packages/engine/src/grabbable/GrabbableComponent.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 
 import { UUIDComponent, getComponent, hasComponent, useEntityContext } from '@ir-engine/ecs'
-import { defineComponent, setComponent, useComponent, useHasComponent } from '@ir-engine/ecs/src/ComponentFunctions'
+import { defineComponent, setComponent, useHasComponent } from '@ir-engine/ecs/src/ComponentFunctions'
 import { Entity } from '@ir-engine/ecs/src/Entity'
 import { defineAction, dispatchAction, getState, isClient } from '@ir-engine/hyperflux'
 import { setCallback } from '@ir-engine/spatial/src/common/CallbackComponent'
@@ -31,7 +31,8 @@ export const GrabbableComponent = defineComponent({
   reactor: function () {
     const entity = useEntityContext()
     const isGrabbed = useHasComponent(entity, GrabbedComponent)
-    const interactableComponent = useComponent(entity, InteractableComponent)
+
+    // useHelperEntity(entity, () => new AxesHelper(0.5), true)
 
     useEffect(() => {
       if (isClient) {

--- a/packages/engine/src/grabbable/GrabbableState.tsx
+++ b/packages/engine/src/grabbable/GrabbableState.tsx
@@ -4,7 +4,6 @@ import {
   entityExists,
   EntityNetworkState,
   EntityUUID,
-  getComponent,
   hasComponent,
   removeComponent,
   setComponent,
@@ -25,10 +24,7 @@ import {
 import { RigidBodyComponent } from '@ir-engine/spatial/src/physics/components/RigidBodyComponent'
 import { BodyTypes } from '@ir-engine/spatial/src/physics/types/PhysicsTypes'
 
-import { getChildrenWithComponents } from '@ir-engine/ecs'
 import { Physics } from '@ir-engine/spatial/src/physics/classes/Physics'
-import { ColliderComponent } from '@ir-engine/spatial/src/physics/components/ColliderComponent'
-import { CollisionGroups } from '@ir-engine/spatial/src/physics/enums/CollisionGroups'
 import '@ir-engine/spatial/src/transform/SpawnPoseState'
 import { GrabbableNetworkAction, GrabbedComponent, GrabberComponent } from './GrabbableComponent'
 
@@ -99,14 +95,6 @@ const GrabbableReactor = ({ entityUUID }: { entityUUID: EntityUUID }) => {
     if (hasComponent(entity, RigidBodyComponent)) {
       setComponent(entity, RigidBodyComponent, { type: BodyTypes.Kinematic })
       Physics.wakeUp(Physics.getWorld(entity)!, entity)
-
-      const colliders = [entity, ...getChildrenWithComponents(entity, [ColliderComponent])]
-
-      for (const collider of colliders) {
-        if (!hasComponent(collider, ColliderComponent)) continue
-        getComponent(collider, ColliderComponent).collisionMask ^= CollisionGroups.Avatars
-        setComponent(collider, ColliderComponent)
-      }
     }
 
     return () => {
@@ -116,14 +104,6 @@ const GrabbableReactor = ({ entityUUID }: { entityUUID: EntityUUID }) => {
       if (hasComponent(entity, RigidBodyComponent)) {
         setComponent(entity, RigidBodyComponent, { type: BodyTypes.Dynamic })
         Physics.wakeUp(Physics.getWorld(entity)!, entity)
-
-        const colliders = [entity, ...getChildrenWithComponents(entity, [ColliderComponent])]
-
-        for (const collider of colliders) {
-          if (!hasComponent(collider, ColliderComponent)) continue
-          getComponent(collider, ColliderComponent).collisionMask ^= CollisionGroups.Avatars
-          setComponent(collider, ColliderComponent)
-        }
       }
     }
   }, [entity, grabberEntity, hasAuthority])

--- a/packages/engine/src/grabbable/GrabbableSystem.tsx
+++ b/packages/engine/src/grabbable/GrabbableSystem.tsx
@@ -49,7 +49,7 @@ const execute = () => {
 
 const executeInput = () => {
   const buttons = InputComponent.getButtons(getState(ReferenceSpaceState).viewerEntity)
-  if (buttons.KeyU?.down) {
+  if (buttons.KeyU?.pressed) {
     const selfAvatarEntity = AvatarComponent.getSelfAvatarEntity()
     if (!selfAvatarEntity) return
     const grabbedComponent = getOptionalComponent(selfAvatarEntity, GrabbedComponent)

--- a/packages/engine/src/interaction/components/InteractableComponent.ts
+++ b/packages/engine/src/interaction/components/InteractableComponent.ts
@@ -272,7 +272,9 @@ export const InteractableComponent = defineComponent({
         if (!interactableComponent.canInteract) return
         const buttons = InputComponent.getButtons(entity)
 
-        if (buttons.Interact?.up && !buttons.Interact?.dragging) {
+        const clicked = interactableComponent.clickInteract && buttons.Interact?.up && !buttons.Interact?.dragging
+        const triggerDown = !interactableComponent.clickInteract && buttons.Interact?.up
+        if (clicked || triggerDown) {
           callInteractCallbacks(entity)
         }
       },

--- a/packages/engine/src/interaction/components/InteractableComponent.ts
+++ b/packages/engine/src/interaction/components/InteractableComponent.ts
@@ -81,6 +81,7 @@ const updateXrDistVec3 = (targetEntity: Entity) => {
 
 const _center = new Vector3()
 const _size = new Vector3()
+const _pos = new Vector3()
 
 export const updateInteractableUI = (entity: Entity) => {
   const targetEntity = AvatarComponent.getSelfAvatarEntity() ?? getState(ReferenceSpaceState).viewerEntity
@@ -100,7 +101,8 @@ export const updateInteractableUI = (entity: Entity) => {
   if (hasVisibleComponent) {
     if (boundingBox) updateBoundingBox(entity)
     if (boundingBox && boundingBox.box && !boundingBox.box.isEmpty()) {
-      const center = boundingBox.box.getCenter(_center)
+      const pos = TransformComponent.getWorldPosition(entity, _pos)
+      const center = boundingBox.box.getCenter(_center).add(pos)
       const size = boundingBox.box.getSize(_size)
       if (!size.y) size.y = 1
       const alpha = smootheLerpAlpha(0.01, getState(ECSState).deltaSeconds)
@@ -154,7 +156,7 @@ export const updateInteractableUI = (entity: Entity) => {
     } else {
       activateUI = interactable.uiVisibilityOverride !== XRUIVisibilityOverride.off //could be more explicit, needs to be if we add more enum options
     }
-    setComponent(entity, InteractableComponent, { canInteract: activateUI })
+    getComponent(entity, InteractableComponent).canInteract = activateUI
   }
 
   //highlight if hovering OR if closest, otherwise turn off highlight
@@ -192,12 +194,10 @@ const addInteractableUI = (entity: Entity) => {
 
   const uiTransform = getComponent(uiEntity, TransformComponent)
   const boundingBox = getOptionalComponent(entity, BoundingBoxComponent)
+  TransformComponent.getWorldPosition(entity, uiTransform.position)
   if (boundingBox && boundingBox.box && !boundingBox.box.isEmpty()) {
     updateBoundingBox(entity)
-    boundingBox.box.getCenter(uiTransform.position)
-  } else {
-    TransformComponent.getWorldPosition(entity, _center)
-    uiTransform.position.copy(_center)
+    uiTransform.position.add(boundingBox.box.getCenter(_center))
   }
   setComponent(entity, InteractableComponent, { uiEntity })
   setComponent(uiEntity, EntityTreeComponent, { parentEntity: getState(ReferenceSpaceState).originEntity })

--- a/packages/engine/src/scene/functions/definePrefab.tsx
+++ b/packages/engine/src/scene/functions/definePrefab.tsx
@@ -61,7 +61,8 @@ import { GLTFComponent } from '../../gltf/GLTFComponent'
  *   schema: Schema.Object({
  *     name: Schema.String()
  *   }),
- *   reactor: ({ entity, prefab }) => {
+ *   reactor: ({ entity }) => {
+ *     const prefab = useComponent(entity, MyPrefabComponent)
  *     useEffect(() => {
  *       setComponent(entity, NameComponent, name)
  *     }, [prefab.name])
@@ -83,7 +84,7 @@ export const definePrefab = <P extends TProperties, S extends TObjectSchema<P>>(
   name: string
   jsonID: string
   schema: S
-  reactor?: (props: { entity: Entity; prefab: Static<S> }) => null | JSX.Element
+  reactor?: (props: { entity: Entity }) => null | JSX.Element
 }) => {
   const $Actions = {
     spawn: defineAction(
@@ -137,8 +138,7 @@ export const definePrefab = <P extends TProperties, S extends TObjectSchema<P>>(
     useImmediateEffect(() => {
       deserializeComponent(entity, $Component, prefab)
     }, [])
-    if (!definition.reactor) return null
-    return <definition.reactor entity={entity} prefab={prefab} />
+    return null
   }
 
   /**
@@ -212,7 +212,8 @@ export const definePrefab = <P extends TProperties, S extends TObjectSchema<P>>(
         }
       }, [isFromScene])
 
-      return null
+      if (!definition.reactor) return null
+      return <definition.reactor entity={entity} />
     }
   })
 

--- a/packages/spatial/src/camera/systems/FollowCameraInputSystem.ts
+++ b/packages/spatial/src/camera/systems/FollowCameraInputSystem.ts
@@ -128,7 +128,6 @@ const execute = () => {
       phi += y * 2
       const pointerDragging = inputSource.buttons?.PrimaryClick?.dragging
       if (pointerDragging || hasPointerLock) {
-        InputState.setCapturingEntity(cameraEntity)
         const inputPointer = getComponent(inputPointerEid, InputPointerComponent)
         pointerPositionDelta.copy(inputPointer.movement)
         phi -= pointerPositionDelta.y * cameraSettings.cameraRotationSpeed
@@ -137,7 +136,7 @@ const execute = () => {
       }
     }
 
-    if (getState(InputState).capturingEntity === cameraEntity) {
+    if (hasPointerLock) {
       setComponent(cameraEntity, TargetCameraRotationComponent, { phi, theta, time })
     }
     handleFollowCameraScroll(cameraEntity, axes, deltaSeconds)

--- a/packages/spatial/src/input/components/InputComponent.ts
+++ b/packages/spatial/src/input/components/InputComponent.ts
@@ -277,8 +277,7 @@ export const InputComponent = defineComponent({
 
   getButtons<BindingsType extends InputButtonBindings = typeof DefaultButtonBindings>(
     entityContext: Entity,
-    inputBindings: BindingsType = DefaultButtonBindings as unknown as BindingsType,
-    autoCapture = true
+    inputBindings: BindingsType = DefaultButtonBindings as unknown as BindingsType
   ) {
     const inputEntity = InputComponent.getInputEntity(entityContext)
     if (inputEntity === UndefinedEntity) return {} as ButtonStateMap<BindingsType>
@@ -288,7 +287,6 @@ export const InputComponent = defineComponent({
         if (!input.buttonBindings[binding]) input.buttonBindings[binding] = inputBindings[binding] as any
       }
     }
-    input.autoCapture = autoCapture
     return input.buttons as ButtonStateMap<BindingsType & typeof DefaultButtonBindings>
   },
 

--- a/packages/spatial/src/physics/classes/Physics.ts
+++ b/packages/spatial/src/physics/classes/Physics.ts
@@ -271,10 +271,6 @@ const setRigidBodyType = (world: PhysicsWorld, entity: Entity, type: Body) => {
   }
 
   rigidbody.setBodyType(typeEnum, true)
-
-  /** @todo turns out this is a react/rapier bug when it comes to changing the rigidbody type. This is the best workaround I could find*/
-  rigidbody.setEnabled(false)
-  rigidbody.setEnabled(true)
 }
 
 function setRigidbodyPose(

--- a/packages/spatial/src/transform/components/BoundingBoxComponent.ts
+++ b/packages/spatial/src/transform/components/BoundingBoxComponent.ts
@@ -13,6 +13,11 @@ export const BOUNDING_BOX_COLORS = {
   HOVERED: '#F3A2FF'
 } as const
 
+/**
+ * BoundingBoxComponent
+ * - Stores an axis-aligned bounding box for an entity
+ * - The box is in world space, relative to the entity's position
+ */
 export const BoundingBoxComponent = defineComponent({
   name: 'BoundingBoxComponent',
 


### PR DESCRIPTION
## Summary

- Fix grabbables
- Fix bug where hand IK only worked if head was also blended
- Fix useQueryBySource always triggering useEffect
- Avoid unnecessary fastSlerp in blendIKChain
- Use keybindings for avatar input
- Fix interactables using bounding box incorrectly
- Disable auto-capture
- Fix pointer lock always capturing input
- Simplify and fix definePrefab
- Replace grabbable layer mutation with avatar movement collider predicate filter

## Subtasks Checklist

## Breaking Changes

## References
closes #_insert number here_

## QA Steps
